### PR TITLE
feat: add optional relative Gaussian noise and seeded RNG to objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,33 @@ python scripts/run.py -m search_method=mcmc,cmaes,da \
 
 Results will be saved in the `results` directory, including performance metrics and optimisation trajectories for each algorithm.
 
+### Noise Addition to Mimic Real-World Scenarios
+You can optionally add relative Gaussian noise to objective evaluations and fix the RNG seed for reproducible runs.
+
+- **relative_gaussian_noise_std**: Multiplicative noise level (σ = |y| × value). Default: `0.0` (disabled).
+- **rng_seed**: Integer seed for deterministic RNG. Default: `0`.
+
+Configure via YAML (e.g., `scripts/conf/run.yaml`):
+
+```yaml
+# scripts/conf/run.yaml
+relative_gaussian_noise_std: 0.01
+rng_seed: 0
+```
+
+Or override from the CLI:
+
+```bash
+python scripts/run.py -m search_method=mcmc,cmaes,da \
+                         obj_func_name=ackley \
+                         dims=10 \
+                         num_acquisitions=100 \
+                         num_samples_per_acquisition=20 \
+                         num_init_samples=50 \
+                         relative_gaussian_noise_std=0.01 \
+                         rng_seed=0
+```
+
 ## Tutorials
 
 We provide detailed tutorials to help you get started with BALSA:

--- a/balsa/active_learning.py
+++ b/balsa/active_learning.py
@@ -115,6 +115,8 @@ class OptimisationConfig:
     search_method_args: dict = field(default_factory=dict)
     func_args: dict = field(default_factory=dict)
     surrogate_args: dict = field(default_factory=dict)
+    relative_gaussian_noise_std: float = 0.0
+    rng_seed: int = 0
 
     def __post_init__(self):
         """Validate configuration parameters."""

--- a/balsa/obj_func.py
+++ b/balsa/obj_func.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Any, override
+from typing import Optional, Dict, Any, override, ClassVar
 
 import numpy as np
+from numpy.random import Generator, default_rng
 from numpy.typing import NDArray
 from balsa.utils import Tracker
 
@@ -14,6 +15,8 @@ class ObjectiveFunction(ABC):
     dims: int = field(default=3)
     name: str = field(init=False)
     turn: float = field(default=0.1)
+    relative_gaussian_noise_std: float = field(default=0.0)
+    rng_seed: int = field(default=0)
     iters: Optional[int] = None
     func_args: Dict[str, Any] = field(default_factory=dict)
 
@@ -21,10 +24,15 @@ class ObjectiveFunction(ABC):
     ub: Optional[NDArray] = None
     counter: int = 0
     tracker: Tracker = field(init=False)
+    rng: Generator = field(init=False, repr=False)
 
     def __post_init__(self):
         """Initialise the tracker after object creation."""
         self.tracker = Tracker(f"{self.name}-{self.dims}")
+        self.rng = default_rng(seed=self.rng_seed)
+
+        if self.relative_gaussian_noise_std < 0:
+            raise ValueError("relative_gaussian_noise_std must be non-negative.")
 
     @abstractmethod
     def _scaled(self, y: float) -> float:
@@ -38,6 +46,22 @@ class ObjectiveFunction(ABC):
         Abstract method to be implemented by subclasses.
         """
         pass
+
+    def _apply_gaussian_noise_relative(self, y: float) -> float:
+        """Add Gaussian noise to the observation if enabled."""
+        if self.relative_gaussian_noise_std <= 0:
+            return y
+        sigma = abs(y) * self.relative_gaussian_noise_std
+        noisy_y = float(y + self.rng.normal(scale=sigma))
+        return noisy_y
+
+    def _finalize_output(
+        self, y: float, x: NDArray, saver: bool, return_scaled: bool
+    ) -> float:
+        """Track the (possibly noisy) value and apply optional scaling."""
+        y_noisy = self._apply_gaussian_noise_relative(y)
+        self.tracker.track(y_noisy, x, saver)
+        return y_noisy if not return_scaled else self._scaled(y_noisy)
 
 
 class Ackley(ObjectiveFunction):
@@ -65,8 +89,7 @@ class Ackley(ObjectiveFunction):
             + 20
             + np.e
         )
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Rastrigin(ObjectiveFunction):
@@ -93,8 +116,7 @@ class Rastrigin(ObjectiveFunction):
         sum = np.sum(x**2 - A * np.cos(2 * np.pi * x))
         y = float(A * n + sum)
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Rosenbrock(ObjectiveFunction):
@@ -117,8 +139,7 @@ class Rosenbrock(ObjectiveFunction):
         assert x.ndim == 1
         y = float(np.sum(100.0 * (x[1:] - x[:-1] ** 2.0) ** 2.0 + (1 - x[:-1]) ** 2.0))
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Griewank(ObjectiveFunction):
@@ -143,8 +164,7 @@ class Griewank(ObjectiveFunction):
         prod_term = np.prod(np.cos(x / np.sqrt(np.arange(1, len(x) + 1))))
         y = float(1 + sum_term / 4000 - prod_term)
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Michalewicz(ObjectiveFunction):
@@ -173,8 +193,7 @@ class Michalewicz(ObjectiveFunction):
             y += float(np.sin(x[i]) * np.sin((i + 1) * x[i] ** 2 / np.pi) ** (2 * m))
         y *= -1.0
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Schwefel(ObjectiveFunction):
@@ -201,12 +220,11 @@ class Schwefel(ObjectiveFunction):
         sum_part = np.sum(-x * np.sin(np.sqrt(np.abs(x))))
 
         if np.all(np.array(x) == 421, axis=0):
-            return 0
+            return self._finalize_output(0.0, x, saver, return_scaled)
 
         y = float(418.9829 * dimension + sum_part)
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Sphere(ObjectiveFunction):
@@ -230,8 +248,7 @@ class Sphere(ObjectiveFunction):
         sum = np.sum(x**2)
         y = float(sum)
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)
 
 
 class Levy(ObjectiveFunction):
@@ -264,5 +281,4 @@ class Levy(ObjectiveFunction):
             )
         y = float(sum)
 
-        self.tracker.track(y, x, saver)
-        return y if not return_scaled else self._scaled(y)
+        return self._finalize_output(y, x, saver, return_scaled)

--- a/scripts/conf/run.yaml
+++ b/scripts/conf/run.yaml
@@ -8,6 +8,8 @@ surrogate: ackley_surrogate
 num_init_samples: 200
 rollout_round: 100
 mode: fast
+relative_gaussian_noise_std: 0.01
+rng_seed: 0
 func_args: {}
 surrogate_args: {}
 


### PR DESCRIPTION
This PR introduces an optional, relative Gaussian noise model and a deterministic random number generator to better emulate real‐world measurement noise while maintaining reproducibility. The default behaviour remains unchanged (noise disabled).

### Notes
- The tracker now records **noisy observations** when noise is enabled.
- Noise is multiplicative: \( $\sigma$ = |y| $\times$ `relative_gaussian_noise_std` \).
- Reproducible runs via `rng_seed`.
- Backwards compatible: with `relative_gaussian_noise_std = 0.0`, outputs and metrics are unchanged.

### Configuration
- YAML (e.g. `scripts/conf/run.yaml`):
  ```yaml
  relative_gaussian_noise_std: 0.01
  rng_seed: 0
  ```
- CLI override:
  ```bash
  python scripts/run.py -m search_method=mcmc,cmaes,da \
                           obj_func_name=ackley \
                           dims=10 \
                           num_acquisitions=100 \
                           num_samples_per_acquisition=20 \
                           num_init_samples=50 \
                           relative_gaussian_noise_std=0.01 \ # Change noise level here, now its 1% Gaussian noise relatively to y
                           rng_seed=0
  ```